### PR TITLE
Specify the mirror server for CRAN in the install command

### DIFF
--- a/denote-explore-network.R
+++ b/denote-explore-network.R
@@ -3,7 +3,7 @@
 # Install required packages
 req_packages <- c("stringr","dplyr", "igraph", "networkD3", "htmlwidgets")
 for (i in req_packages) { #Installs packages if not yet installed
-  if(! i%in% row.names(installed.packages())) install.packages(i)
+  if(! i%in% row.names(installed.packages())) install.packages(i, repos = "http://cran.us.r-project.org")
 }
 
 ## Initialise libraries.


### PR DESCRIPTION
As someone with no experience with R, I just installed R using
     `brew install --cask R`
and tried to run the script with
     `Rscript denote-explore-network.R`

It threw the error:

```
Error in contrib.url(repos, "source") :
  trying to use CRAN without setting a mirror
Calls: install.packages -> contrib.url
Execution halted
```

Google told me that the `repos` parameter would tell R where to install the packages from, and this change fixed the script for me.

Thanks!