### PR TITLE
Customization types incorrect

### DIFF
--- a/denote-explore.el
+++ b/denote-explore.el
@@ -92,13 +92,14 @@ File type defined with `denote-explore-network-format'."
   "List of keywords to be ignored in the keywords graph."
   :group 'denote-explore
   :package-version '(denote-explore . "1.3")
-  :type 'list)
+  :type '(repeat (string :tag "Keyword")))
 
 (defcustom denote-explore-network-regex-ignore '()
   "Regular expression for notes ignored in neighbourhood and community graphs."
   :group 'denote-explore
   :package-version '(denote-explore . "1.4")
-  :type 'list)
+  :type '(choice (const :tag "No Ignore Regexp" nil)
+                 (regexp :tag "Ignore using Regexp")))
 
 (defcustom denote-explore-network-graphviz-header
   '("layout=neato"


### PR DESCRIPTION
The customization types for `denote-explore-network-keywords-ignore` and `denote-explore-network-regex-ignore` are incorrect.  Using `(setopt denote-explore-network-keywords-ignore '("bib"))` in Emacs 29.2 will show a warning: `Warning (emacs): Value ‘("bib")’ does not match type list`.