### PR TITLE
Add command to visualise backlinks

### DIFF
--- a/denote-explore.el
+++ b/denote-explore.el
@@ -579,6 +579,18 @@ of a file."
                   (setq degree (+ degree 1))))
 	      (append node (list (cons 'degree degree))))) nodes))
 
+(defun denote-explore--network-backlinks (nodes edges)
+"Calculate the number of backlinks for each node in a network graph NODES and
+EDGES."
+  (mapcar (lambda (node)
+            (let ((node-id (cdr (assoc 'id node)))
+                  (backlinks 0))
+              (dolist (edge edges)
+                (when (string= node-id (cdr (assoc 'target edge)))
+                  (setq backlinks (+ backlinks (cdr (assoc 'weight edge))))))
+              (append node (list (cons 'backlinks backlinks)))))
+        nodes))
+
 (defun denote-explore--network-filter-files (files)
   "Remove files matching `denote-explore-network-regex-ignore' from Denote FILES.
 Removes selected files from neighbourhood or community visualisation."
@@ -597,7 +609,8 @@ Links to notes outside the search area are pruned."
 	    (edges-pruned (denote-explore--network-prune-edges ids edges))
 	    (edges-alist (denote-explore--network-count-edges edges-pruned))
 	    (nodes (mapcar #'denote-explore--network-extract-node files))
-	    (nodes-alist (denote-explore--network-degree nodes edges-alist))
+	    (nodes-alist-1 (denote-explore--network-degree nodes edges-alist))
+	    (nodes-alist (denote-explore--network-backlinks nodes-alist-1 edges-alist))
 	    (meta-alist `((directed . t) (type . ,(format "Community '%s'" regex)))))
       `((meta . ,meta-alist) (nodes . ,nodes-alist) (edges . ,edges-alist))
     (user-error "No Denote files or (back)links found for %s" regex)))

--- a/denote-explore.el
+++ b/denote-explore.el
@@ -465,6 +465,22 @@ VAR and TITLE used for display."
     (denote-explore--barchart txt-degrees "Degree" "Node degree distribution")))
 
 ;;;###autoload
+(defun denote-explore-backlinks-barchart (n)
+  "Visualise the number of backlinks for each node in the Denote network."
+  (interactive "nNumber of nodes: ")
+  (message "Analysing Denote network.")
+  (let* ((graph (denote-explore-network-community-graph ""))
+	     (nodes (cdr (assoc 'nodes graph)))
+         (backlinks (mapcar (lambda (node)
+                              (cons
+                               (cdr (assq 'name node))
+                               (cdr (assq 'backlinks node))))
+                            nodes)))
+    (sort backlinks (lambda (a b)
+                      (> (cdr a) (cdr b))))
+    (denote-explore--barchart backlinks "Backlinks" "Node backlinks distribution" n)))
+
+;;;###autoload
 (defun denote-explore-isolated-notes (&optional include-attachments)
   "Identify Denote files without (back)links and optionally INCLUDE-ATTACHMENTS.
 Using the universal argument includes attachments."


### PR DESCRIPTION
Adds the command `denote-explore-backlinks-barchart`, which shows the top N nodes sorted by backlink count along with their number of backlinks.

I'm not sure about the implementation of `backlinks` as a property of nodes in the graph. I created a separate `denote-explore--network-backlinks` to calculate them, but it could also be folded into `denote-explore--network-degree` by calculating the in-degree and out-degree separately.