### PR TITLE
Implement multiple ways to view duplicate notes

### DIFF
--- a/denote-explore.el
+++ b/denote-explore.el
@@ -341,6 +341,25 @@ suspected duplicate files."
   "1.2")
 
 ;;;###autoload
+(defun denote-explore-identify-duplicate-notes-dired (&optional filenames)
+  "Identify duplicate Denote IDs or FILENAMES.
+
+If FILENAMES is nil, check Denote IDs, otherwise use complete file names.
+Using the FILENAMES option (or using the universal argument) excludes
+exported Denote files from duplicate-detection.
+
+Duplicate files are displayed `find-dired'."
+  (interactive "P")
+  (let* ((duplicates (denote-explore--duplicate-notes filenames)))
+    (if (not duplicates)
+        (message "No duplicates found")
+      (find-dired denote-directory
+                  (mapconcat (lambda (id)
+                               (format "-name '%s*'" id))
+                             duplicates
+                             " -o ")))))
+
+;;;###autoload
 (defun denote-explore-single-keywords ()
   "Select a note or attachment with a keyword that is only used once."
   (interactive)

--- a/denote-explore.el
+++ b/denote-explore.el
@@ -292,6 +292,23 @@ With universal argument the sample includes attachments."
   (sort (-frequencies list)
         (lambda (a b) (> (cdr a) (cdr b)))))
 
+(defun denote-explore--duplicate-notes (strict-filenames-p)
+  "Find duplicate Denote IDs.
+
+When STRICT-FILENAMES-P, use complete filenames, not merely IDs."
+  (let* ((denote-files (denote-directory-files))
+         (candidates (if strict-filenames-p
+                         (mapcar (lambda (path)
+				   (file-name-nondirectory path))
+				 denote-files)
+                       (mapcar #'denote-retrieve-filename-identifier
+			       denote-files)))
+         (tally (denote-explore--table candidates)))
+    (mapcar #'car (cl-remove-if-not
+                   (lambda (note)
+		     (> (cdr note) 1))
+		   tally))))
+
 ;;;###autoload
 (defun denote-explore-identify-duplicate-notes (&optional filenames)
   "Identify duplicate Denote IDs or FILENAMES.
@@ -303,18 +320,7 @@ exported Denote files from duplicate-detection.
 Duplicate files are displayed in a temporary buffer with links to the
 suspected duplicate files."
   (interactive "P")
-  (let* ((denote-files (denote-directory-files))
-         (candidates (if filenames
-                         (mapcar (lambda (path)
-				   (file-name-nondirectory path))
-				 denote-files)
-                       (mapcar #'denote-retrieve-filename-identifier
-			       denote-files)))
-         (tally (denote-explore--table candidates))
-         (duplicates (mapcar #'car (cl-remove-if-not
-                                    (lambda (note)
-				      (> (cdr note) 1))
-				    tally))))
+  (let* ((duplicates (denote-explore--duplicate-notes filenames)))
     (if (not duplicates)
         (message "No duplicates found")
       (with-current-buffer-window "*denote-duplicates*" nil nil

--- a/denote-explore.org
+++ b/denote-explore.org
@@ -51,7 +51,7 @@ Besides my Denote-generated notes, I have historical attachments in my collectio
 
 Adding the Denote identifier manually introduces a risk of duplication. Duplicates can also arise when exporting Denote Org mode files, as the exported files have the same file name but a different extension.
 
-The ~denote-explore-identify-duplicate-notes~ command lists all duplicate identifiers in a temporary buffer. The temporary buffer includes links to the suspected duplicate notes and attachments.
+The ~denote-explore-identify-duplicate-notes~ command lists all duplicate identifiers in a temporary buffer. The temporary buffer includes links to the suspected duplicate notes and attachments.  Additionally, the ~denote-explore-identify-duplicate-notes-dired~ command will show them in a Dired buffer.
 
 Be careful when changing the identifier of a Denote file, as it can destroy the integrity of your links, so please ensure that the file you rename does not have any links pointing to it. You can use the ~denote-find-link~ and ~denote-find-backlink~ commands to check a file for links.
 


### PR DESCRIPTION
This PR does the following:

 - Separates duplicate note detection from display
 - Implements a secondary display using `find-dired` 

See also #19.