### PR TITLE
feat(denote-explore-network-directory): auto add trailing slash if omitted

### DIFF
--- a/denote-explore.el
+++ b/denote-explore.el
@@ -1336,7 +1336,7 @@ Optionally analyse TEXT-ONLY files."
 			denote-explore-network-graph-formats))
 	 (convert-fn (plist-get (cdr format) :encode))
 	 (file-extension (plist-get (cdr format) :file-extension))
-	 (file-name (concat denote-explore-network-directory
+	 (file-name (file-name-concat denote-explore-network-directory
 			    denote-explore-network-filename file-extension)))
     (when (not (file-exists-p denote-explore-network-directory))
       (make-directory denote-explore-network-directory))

--- a/denote-explore.el
+++ b/denote-explore.el
@@ -1337,7 +1337,7 @@ Optionally analyse TEXT-ONLY files."
 	 (convert-fn (plist-get (cdr format) :encode))
 	 (file-extension (plist-get (cdr format) :file-extension))
 	 (file-name (file-name-concat denote-explore-network-directory
-			    denote-explore-network-filename file-extension)))
+			    (concat denote-explore-network-filename file-extension))))
     (when (not (file-exists-p denote-explore-network-directory))
       (make-directory denote-explore-network-directory))
     (with-temp-file file-name (funcall convert-fn graph))


### PR DESCRIPTION
Hello,

Thanks for the share of this useful plugin for denote. I spent some time debugging a mistake I did when setting the directory without a trailing slash which was making the generation crash (not finding the json generated file).
Here is a little contribution which I hope will avoid this kind of surprise to further users...