### PR TITLE
fix: added missing dependency denote-sequence

### DIFF
--- a/denote-explore.el
+++ b/denote-explore.el
@@ -5,7 +5,7 @@
 ;; Author: Peter Prevos <peter@prevos.net>
 ;; URL: https://github.com/pprevos/denote-explore/
 ;; Version: 4.1
-;; Package-Requires: ((emacs "29.1") (denote "4.0") (dash "2.19.1") (denote-regexp "20250415.2202"))
+;; Package-Requires: ((emacs "29.1") (denote "4.0") (denote-sequence "0.3.3") (dash "2.19.1") (denote-regexp "20250415.2202"))
 ;;
 ;; This file is NOT part of GNU Emacs.
 ;;


### PR DESCRIPTION
The dependency was introduced by commit e0265d4, which merged PR #48.

Feel free to adjust the `denote-sequence` version and the order of the dependency as you see fit.  I simply used the latest version and placed it right behind `denote`.